### PR TITLE
Some minor tweaks

### DIFF
--- a/javascript/iepp.js
+++ b/javascript/iepp.js
@@ -6,20 +6,20 @@
 	}
 	win.iepp = win.iepp || {};
 	var iepp = win.iepp,
-		elems = iepp.html5elements || 'abbr|article|aside|audio|canvas|datalist|details|figcaption|figure|footer|header|hgroup|mark|meter|nav|output|progress|section|summary|time|video',
-		elemsArr = elems.split('|'),
-		elemsArrLen = elemsArr.length,
-		elemRegExp = new RegExp('(^|\\s)('+elems+')', 'gi'), 
-		tagRegExp = new RegExp('<(\/*)('+elems+')', 'gi'),
-		filterReg = /^\s*[\{\}]\s*$/,
-		ruleRegExp = new RegExp('(^|[^\\n]*?\\s)('+elems+')([^\\n]*)({[\\n\\w\\W]*?})', 'gi'),
-		docFrag = doc.createDocumentFragment(),
-		html = doc.documentElement,
-		head = html.firstChild,
-		bodyElem = doc.createElement('body'),
-		styleElem = doc.createElement('style'),
-		printMedias = /print|all/,
-		body;
+	    elems = iepp.html5elements || 'abbr|article|aside|audio|canvas|datalist|details|figcaption|figure|footer|header|hgroup|mark|meter|nav|output|progress|section|summary|time|video',
+	    elemsArr = elems.split('|'),
+	    elemsArrLen = elemsArr.length,
+	    elemRegExp = new RegExp('(^|\\s)('+elems+')', 'gi'),
+	    tagRegExp = new RegExp('<(\/*)('+elems+')', 'gi'),
+	    filterReg = /^\s*[\{\}]\s*$/,
+	    ruleRegExp = new RegExp('(^|[^\\n]*?\\s)('+elems+')([^\\n]*)({[\\n\\w\\W]*?})', 'gi'),
+	    docFrag = doc.createDocumentFragment(),
+	    html = doc.documentElement,
+	    head = html.firstChild,
+	    bodyElem = doc.createElement('body'),
+	    styleElem = doc.createElement('style'),
+	    printMedias = /print|all/,
+	    body;
 	function shim(doc) {
 		var a = -1;
 		while (++a < elemsArrLen) {
@@ -27,15 +27,15 @@
 			doc.createElement(elemsArr[a]);
 		}
 	}
-	
+
 	iepp.getCSS = function(styleSheetList, mediaType) {
 		if (!styleSheetList) {
 			return '';
 		}
 		var a = -1,
-			len = styleSheetList.length,
-			styleSheet,
-			cssTextArr = [];
+		    len = styleSheetList.length,
+		    styleSheet,
+		    cssTextArr = [];
 		while (++a < len) {
 			styleSheet = styleSheetList[a];
 			//currently no test for disabled/alternate stylesheets
@@ -50,24 +50,24 @@
 		}
 		return cssTextArr.join('');
 	};
-	
+
 	iepp.parseCSS = function(cssText) {
 		var cssTextArr = [],
-			rule;
+		    rule;
 		while ((rule = ruleRegExp.exec(cssText)) != null){
 			// Replace all html5 element references with iepp substitute classnames
-			cssTextArr.push(( (filterReg.exec(rule[1]) ? '\n' : rule[1]) +rule[2]+rule[3]).replace(elemRegExp, '$1.iepp-$2')+rule[4]);
+			cssTextArr.push(( (filterReg.exec(rule[1]) ? '\n' : rule[1]) + rule[2] + rule[3]).replace(elemRegExp, '$1.iepp-$2') + rule[4]);
 		}
 		return cssTextArr.join('\n');
 	};
-	
+
 	iepp.writeHTML = function() {
 		var a = -1;
 		body = body || doc.body;
 		while (++a < elemsArrLen) {
 			var nodeList = doc.getElementsByTagName(elemsArr[a]),
-				nodeListLen = nodeList.length,
-				b = -1;
+			    nodeListLen = nodeList.length,
+			    b = -1;
 			while (++b < nodeListLen)
 				if (nodeList[b].className.indexOf('iepp-') < 0)
 					// Append iepp substitute classnames to all html5 elements
@@ -81,36 +81,36 @@
 		// Replace HTML5 elements with <font> which is print-safe and shouldn't conflict since it isn't part of html5
 		bodyElem.innerHTML = body.innerHTML.replace(tagRegExp, '<$1font');
 	};
-	
-	
+
+
 	iepp._beforePrint = function() {
 		// Write iepp custom print CSS
 		styleElem.styleSheet.cssText = iepp.parseCSS(iepp.getCSS(doc.styleSheets, 'all'));
 		iepp.writeHTML();
 	};
-	
+
 	iepp.restoreHTML = function() {
 		// Undo everything done in onbeforeprint
 		bodyElem.innerHTML = '';
 		html.removeChild(bodyElem);
 		html.appendChild(body);
 	};
-	
+
 	iepp._afterPrint = function() {
 		// Undo everything done in onbeforeprint
 		iepp.restoreHTML();
 		styleElem.styleSheet.cssText = '';
 	};
-	
+
 	// Shim the document and iepp fragment
 	shim(doc);
 	shim(docFrag);
-	
+
 	//
 	if (iepp.disablePP) {
 		return;
 	}
-	
+
 	// Add iepp custom print style element
 	head.insertBefore(styleElem, head.firstChild);
 	styleElem.media = 'print';


### PR DESCRIPTION
Currently, `-` occurs 9 times and `_` 8 times in `iepp.js`.

Using `iepp-` instead of `iepp_` as prefix will make those numbers `12` and `5` for the CSS classes will result in better gzip compression, saving 3 bytes!!1omg.

Also I did some other small tweaks.
