### PR TITLE
Ability to add extra elements to shim, rather than override all html5elements

### DIFF
--- a/src/iepp.js
+++ b/src/iepp.js
@@ -4,9 +4,11 @@
 	if ( !window.attachEvent || !doc.createStyleSheet || !(function(){ var elem = document.createElement("div"); elem.innerHTML = "<elem></elem>"; return elem.childNodes.length !== 1; })()) {
 		return;
 	}
+
 	win.iepp = win.iepp || {};
 	var iepp = win.iepp,
-		elems = iepp.html5elements || 'abbr|article|aside|audio|canvas|data|datalist|details|figcaption|figure|footer|header|hgroup|mark|meter|nav|output|progress|section|subline|summary|time|video',
+		baseElems = iepp.html5elements || 'abbr|article|aside|audio|canvas|data|datalist|details|figcaption|figure|footer|header|hgroup|mark|meter|nav|output|progress|section|subline|summary|time|video',
+		elems = baseElems + (iepp.extraElements ? '|' + iepp.extraElements : ''),
 		elemsArr = elems.split('|'),
 		elemsArrLen = elemsArr.length,
 		elemRegExp = new RegExp('(^|\\s)('+elems+')', 'gi'), 


### PR DESCRIPTION
This is a fairly specific use, but we're using custom markup in a templating system. While we want to shim all html5 elements, we also wanted to shim our custom markup. Rather than override the entire html5elements property I've added an extraElements property which is added to the list. 

usage:

```
iepp = { extraElements: 'datarepeater|data' };
```

prior to loading Modernizr (or iepp). 
