### PR TITLE
Add Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,12 @@
   ],
   "require": {
     "robloach/component-installer": "*"
+  },
+  "extra": {
+    "component": {
+      "scripts": [
+        "dist/html5shiv.js"
+      ]
+    }
   }
 }


### PR DESCRIPTION
[Composer](http://getcomposer.org) is a package manager for PHP. This allows HTML5 Shiv to be downloaded by putting `"afarkas/html5shiv"` into your own `composer.json` file.

``` json
{
  "require": {
    "afarkas/html5shiv": "3.6.*"
  }
}
```
