### PR TITLE
Updated Type check for shived innerHTML

### DIFF
--- a/src/html5shiv-printshiv.js
+++ b/src/html5shiv-printshiv.js
@@ -113,6 +113,9 @@
                     return innerDesc.set.apply(elem, arguments);
                 }
                 shived = {};
+                if((typeof content).toLowerCase() === "number"){
+                  content = content.toString()
+                }
                 innerDesc.set.call(elem, content.replace(/<(\w+)/g, function (m, m1) {
                     if (!shived[m1]) {
                         shived[m1] = true;

--- a/src/html5shiv.js
+++ b/src/html5shiv.js
@@ -112,6 +112,9 @@
                 if (!elem.canHaveChildren || elem.document == ownerDocument || !html5.shivMethods) {
                     return innerDesc.set.apply(elem, arguments);
                 }
+                if((typeof content).toLowerCase() === "number"){
+                  content = content.toString()
+                }
                 shived = {};
                 innerDesc.set.call(elem, content.replace(/<(\w+)/g, function (m, m1) {
                     if (!shived[m1]) {


### PR DESCRIPTION
The "content" parameter for "innerHTML" was not coerced to a string in the event it is a "Number"  type. IE8 internal handles this for standard elements.
