### PR TITLE
Fails to function if included at end of document

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,8 @@ For the full story of HTML5 Shiv and all of the people involved in making it, re
 
 ## Installation
 
+**Note:** HTML5 Shiv must be included in the page *before* any HTML5 element can be used in the DOM. Therefore it is necessary, not just recommended, to include it in the `head`.
+
 ###Using [Bower](http://bower.io/)
 
 `bower install html5shiv --save-dev`


### PR DESCRIPTION
Is this a known issue? If html5shiv is included at the bottom of the document (as is normally advised for scripts), any elements already in the DOM are not fixed.

This holds true regardless where the shim is inserted: i.e. any HTML5 elements already in the DOM prior to the shim are not fixed (so they don't get styling).

If this is a known issue, I'll submit a PR to add a note to the readme about this. 
