### PR TITLE
Supports tag names with hyphens like foo-bar.

### DIFF
--- a/src/html5shiv.js
+++ b/src/html5shiv.js
@@ -187,7 +187,7 @@
       'var n=f.cloneNode(),c=n.createElement;' +
       'h.shivMethods&&(' +
         // unroll the `createElement` calls
-        getElements().join().replace(/\w+/g, function(nodeName) {
+        getElements().join().replace(/[\w\-]+/g, function(nodeName) {
           data.createElem(nodeName);
           data.frag.createElement(nodeName);
           return 'c("' + nodeName + '")';


### PR DESCRIPTION
This fixes Issue #123.  If someone provides a tag name like "tag-name", the current document.createDocumentFragment only creates a "tag" and "name" element.  This fixes the regular expression used to match against the joined elements array.
