### PR TITLE
Changed bower install instruction

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ Include the HTML5 shiv in the `<head>` of your page in a conditional comment and
 
 ```html
 <!--[if lt IE 9]>
-	<script src="components/html5shiv/html5shiv.js"></script>
+	<script src="bower_components/html5shiv/dist/html5shiv.js"></script>
 <![endif]-->
 ```
 


### PR DESCRIPTION
I made a small change to the bower install instruction so it uses `--save` instead of `--save-dev`. I think that it is a better way to consume html5shiv, because you would want to use it in production and not while development.

I updated the bower installation path, too.
