### PR TITLE
Changed mentions of Bower `components` folder to `bower_components`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,13 +24,13 @@ For the full story of HTML5 Shiv and all of the people involved in making it, re
 
 `bower install html5shiv --save-dev`
 
-This will clone the latest version of the HTML5 shiv into the `components` directory at the root of your project and also create or update the file `bower.json` which specifies your projects dependencies.
+This will clone the latest version of the HTML5 shiv into the `bower_components` directory at the root of your project and also create or update the file `bower.json` which specifies your projects dependencies.
 
 Include the HTML5 shiv in the `<head>` of your page in a conditional comment and after any stylesheets.
 
 ```html
 <!--[if lt IE 9]>
-	<script src="components/html5shiv/html5shiv.js"></script>
+	<script src="bower_components/html5shiv/html5shiv.js"></script>
 <![endif]-->
 ```
 


### PR DESCRIPTION
Bower.io clones dependancies in a `./bower_components` folder, not `./components/`. 
