### PR TITLE
Bumped the version number to 3.7.1 in `bower.json`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "html5shiv",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "main": [
   	"dist/html5shiv.js"
   ],


### PR DESCRIPTION
I updated the `bower.json` version nr to the (new) 3.7.1 release. This—presumably—allows us to run `bower update html5shiv`…
