### PR TITLE
Ignore Node generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+
+# Node generated files
+node_modules
+npm-debug.log


### PR DESCRIPTION
Updated `.gitignore` to ignore the `node_modules` directory and `npm-debug.log`.
