### PR TITLE
Composer: Remove dependency on component-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,6 @@
     "MIT",
     "GPL-2.0"
   ],
-  "require": {
-    "robloach/component-installer": "*"
-  },
   "extra": {
     "component": {
       "scripts": [


### PR DESCRIPTION
While it can be used, it is not an absolute requirement.