### PR TITLE
Fixes an annotation for createElement

### DIFF
--- a/src/html5shiv.js
+++ b/src/html5shiv.js
@@ -121,7 +121,7 @@
    * returns a shived element for the given nodeName and document
    * @memberOf html5
    * @param {String} nodeName name of the element
-   * @param {Document} ownerDocument The context document.
+   * @param {Document|DocumentFragment} ownerDocument The context document.
    * @returns {Object} The shived element.
    */
   function createElement(nodeName, ownerDocument, data){


### PR DESCRIPTION
My (quite old) Google Closure Compiler complained about:

```
utils/third_party/html5shiv.js:206: WARNING - actual parameter 2 of createElement does not match formal parameter
found   : (Document|DocumentFragment|null)
required: (Document|null)
      return createElement(nodeName, ownerDocument, data);
```